### PR TITLE
Build LilyPond from source

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to DockerHub
@@ -53,6 +55,7 @@ jobs:
             jeandeaual/lilypond:${{ github.event.inputs.version }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
       - name: Image digest (latest)
         if: github.event.inputs.latest == 'true'
         run: echo ${{ steps.docker_build_latest.outputs.digest }}
@@ -69,6 +72,7 @@ jobs:
             jeandeaual/lilypond:${{ github.event.inputs.version }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
       - name: Image digest
         if: github.event.inputs.latest != 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
@@ -85,6 +89,7 @@ jobs:
             jeandeaual/lilypond:${{ github.event.inputs.version }}-fonts
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
       - name: Image digest (fonts)
         run: echo ${{ steps.docker_build_fonts.outputs.digest }}
       - name: Build and push (ly2video)
@@ -100,6 +105,7 @@ jobs:
             jeandeaual/lilypond:${{ github.event.inputs.version }}-ly2video
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
       - name: Image digest (ly2video)
         run: echo ${{ steps.docker_build_ly2video.outputs.digest }}
       - name: Build and push (fonts & ly2video)
@@ -115,5 +121,6 @@ jobs:
             jeandeaual/lilypond:${{ github.event.inputs.version }}-fonts-ly2video
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
+          platforms: linux/amd64,linux/arm64
       - name: Image digest (fonts & ly2video)
         run: echo ${{ steps.docker_build_ly2video.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,12 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
       - name: Cache Docker layers
         uses: actions/cache@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,51 @@
 # ARGs used in FROM need to be declared before the first FROM
 # See https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact
 ARG suffix=""
+ARG lilypond_version="2.22.0"
+
+FROM debian:bullseye-slim AS build
+
+SHELL ["/bin/bash", "-c"]
+
+RUN printf 'LANG="C"\nLANGUAGE="C"\nLC_ALL="C"\n' > /etc/default/locale
+
+RUN echo "deb-src http://deb.debian.org/debian bullseye main" >> /etc/apt/sources.list
+
+RUN source /etc/default/locale \
+  && apt-get update \
+  # Install the LilyPond build dependencies
+  && apt-get build-dep -y lilypond \
+  && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    # To get newer config.sub and config.guess
+    autotools-dev \
+    # LilyPond build dependencies
+    git \
+    guile-2.2-dev \
+    install-info \
+    python3 \
+    python-is-python3
+
+WORKDIR /build
+
+ARG lilypond_version
+
+# Install LilyPond
+RUN git clone --no-tags --single-branch --depth 1 --branch "release/${lilypond_version}-1" https://git.savannah.gnu.org/git/lilypond.git
+
+WORKDIR /build/lilypond
+
+RUN ./autogen.sh --noconfigure \
+  # Update the configure script (required to build on arm64)
+  && cp /usr/share/misc/config.{sub,guess} ./config/ \
+  && mkdir build
+
+WORKDIR /build/lilypond/build
+
+RUN mkdir /lilypond \
+  && ../configure --prefix /lilypond --disable-debugging --disable-documentation \
+  && make -j$(cat /sys/fs/cgroup/cpuset/cpuset.cpus | cut -d- -f 2) \
+  && make install
 
 FROM debian:bullseye-slim AS lilypond
 
@@ -9,28 +54,20 @@ SHELL ["/bin/bash", "-c"]
 RUN printf 'LANG="C"\nLANGUAGE="C"\nLC_ALL="C"\n' > /etc/default/locale
 
 RUN source /etc/default/locale \
-  && export DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
   && apt-get install -y --no-install-recommends \
-    locales \
-    make \
-    qpdf \
-    # Required by the LilyPond installation script
-    bzip2
+    ca-certificates \
+    # LilyPond run dependencies
+    libglib2.0-0 \
+    guile-2.2 \
+    libpangoft2-1.0-0 \
+    fontconfig \
+    fonts-dejavu \
+    ghostscript \
+    # To transform PDFs (e.g. rotate)
+    qpdf
 
-WORKDIR /install
-
-ARG lilypond_version="2.22.0"
-
-# Install LilyPond
-ADD "https://lilypond.org/download/binaries/linux-64/lilypond-${lilypond_version}-1.linux-64.sh" ./
-RUN chmod +x "lilypond-${lilypond_version}-1.linux-64.sh"
-RUN "./lilypond-${lilypond_version}-1.linux-64.sh" --batch --prefix /lilypond
-
-WORKDIR /app
-
-# Cleanup
-RUN rm -rf /install
+COPY --from=build /lilypond /lilypond
 
 ENV PATH "/lilypond/bin:${PATH}"
 
@@ -40,6 +77,8 @@ FROM lilypond AS lilypond-fonts
 SHELL ["/bin/bash", "-c"]
 
 COPY install-lilypond-fonts.sh install-system-fonts.sh ./
+
+ARG lilypond_version
 
 # Install fonts for LilyPond
 RUN apt-get install -y --no-install-recommends \
@@ -56,12 +95,8 @@ RUN apt-get install -y --no-install-recommends \
   # Manual system font installation (not in the repositories)
   && ./install-system-fonts.sh \
   # LilyPond font installation
-  && ./install-lilypond-fonts.sh /lilypond/lilypond/usr/share/lilypond/current \
-  # Cleanup
-  && fc-cache -fv \
-  && apt-get remove -y bzip2 wget xz-utils \
-  && apt-get autoremove -y \
-  && apt-get clean -y
+  && ./install-lilypond-fonts.sh "/lilypond/share/lilypond/${lilypond_version}" \
+  && fc-cache -fv
 
 # Image with ly2video
 FROM lilypond AS lilypond-ly2video
@@ -87,11 +122,7 @@ RUN apt-get install -y --no-install-recommends \
   # Required by Pillow
   libjpeg-dev \
   zlib1g-dev \
-  && ./install-ly2video.sh \
-  # Cleanup
-  && apt-get remove -y build-essential python3-dev libasound-dev libjpeg-dev zlib1g-dev \
-  && apt-get autoremove -y \
-  && apt-get clean -y
+  && ./install-ly2video.sh
 
 # Image with both the fonts and ly2video
 FROM lilypond-fonts AS lilypond-fonts-ly2video
@@ -115,10 +146,7 @@ RUN apt-get install -y --no-install-recommends \
   # Required by Pillow
   libjpeg-dev \
   zlib1g-dev \
-  && ./install-ly2video.sh \
-  && apt-get remove -y build-essential python3-dev libasound-dev libjpeg-dev zlib1g-dev \
-  && apt-get autoremove -y \
-  && apt-get clean -y
+  && ./install-ly2video.sh
 
 # Final image
 FROM lilypond${suffix} AS final
@@ -126,6 +154,11 @@ FROM lilypond${suffix} AS final
 LABEL maintainer="alexis.jeandeau@gmail.com"
 
 # Cleanup
-RUN rm -rf /var/lib/apt/lists/*
+RUN apt-get remove -y bzip2 wget xz-utils build-essential python3-dev libasound-dev libjpeg-dev zlib1g-dev \
+  && apt-get autoremove -y \
+  && apt-get clean -y \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 CMD ["lilypond", "-v"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,8 @@ RUN source /etc/default/locale \
     fontconfig \
     fonts-dejavu \
     ghostscript \
+    # LilyPond optional dependencies
+    extractpdfmark \
     # To transform PDFs (e.g. rotate)
     qpdf
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ In order to run this container you'll need [Docker](https://docs.docker.com/get-
 
 * `stable` (latest [stable version](https://lilypond.org/download.html))
     * `2.22.0`
-    * `2.20.0`
-    * `2.18.2`
-    * `2.18.1`
-    * `2.18.0`
 * `devel` (latest [development version](https://lilypond.org/development.html))
     * `2.23.0`
     * `2.21.82`


### PR DESCRIPTION
This allows us to:

* Reduce the base image size (about 80 MB compressed)
* Build for other architectures (e.g. linux/arm64)