### PR TITLE
Add Spontini editor to the images

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -86,35 +86,35 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Image digest (fonts)
         run: echo ${{ steps.docker_build_fonts.outputs.digest }}
-      - name: Build and push (ly2video)
-        id: docker_build_ly2video
+      - name: Build and push (tools)
+        id: docker_build_tools
         uses: docker/build-push-action@v2
         with:
           push: true
           build-args: |
             LILYPOND_VERSION=${{ github.event.inputs.version }}
-            SUFFIX=-ly2video
+            SUFFIX=-tools
           tags: |
-            jeandeaual/lilypond:${{ github.event.inputs.tag}}-ly2video
-            jeandeaual/lilypond:${{ github.event.inputs.version }}-ly2video
+            jeandeaual/lilypond:${{ github.event.inputs.tag}}-tools
+            jeandeaual/lilypond:${{ github.event.inputs.version }}-tools
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64
-      - name: Image digest (ly2video)
-        run: echo ${{ steps.docker_build_ly2video.outputs.digest }}
-      - name: Build and push (fonts & ly2video)
-        id: docker_build_fonts_ly2video
+      - name: Image digest (tools)
+        run: echo ${{ steps.docker_build_tools.outputs.digest }}
+      - name: Build and push (fonts & tools)
+        id: docker_build_fonts_tools
         uses: docker/build-push-action@v2
         with:
           push: true
           build-args: |
             LILYPOND_VERSION=${{ github.event.inputs.version }}
-            SUFFIX=-fonts-ly2video
+            SUFFIX=-fonts-tools
           tags: |
-            jeandeaual/lilypond:${{ github.event.inputs.tag}}-fonts-ly2video
-            jeandeaual/lilypond:${{ github.event.inputs.version }}-fonts-ly2video
+            jeandeaual/lilypond:${{ github.event.inputs.tag}}-fonts-tools
+            jeandeaual/lilypond:${{ github.event.inputs.version }}-fonts-tools
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64
-      - name: Image digest (fonts & ly2video)
-        run: echo ${{ steps.docker_build_ly2video.outputs.digest }}
+      - name: Image digest (fonts & tools)
+        run: echo ${{ steps.docker_build_tools.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,35 +81,35 @@ jobs:
           platforms: linux/amd64,linux/arm64
       - name: Image digest (fonts)
         run: echo ${{ steps.docker_build_fonts.outputs.digest }}
-      - name: Build (ly2video)
-        id: docker_build_ly2video
+      - name: Build (tools)
+        id: docker_build_tools
         uses: docker/build-push-action@v2
         with:
           push: false
           build-args: |
             LILYPOND_VERSION=${{ github.event.inputs.version }}
-            SUFFIX=-ly2video
+            SUFFIX=-tools
           tags: |
-            jeandeaual/lilypond:${{ github.event.inputs.tag}}-ly2video
-            jeandeaual/lilypond:${{ github.event.inputs.version }}-ly2video
+            jeandeaual/lilypond:${{ github.event.inputs.tag}}-tools
+            jeandeaual/lilypond:${{ github.event.inputs.version }}-tools
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64
-      - name: Image digest (ly2video)
-        run: echo ${{ steps.docker_build_ly2video.outputs.digest }}
-      - name: Build (fonts & ly2video)
-        id: docker_build_fonts_ly2video
+      - name: Image digest (tools)
+        run: echo ${{ steps.docker_build_tools.outputs.digest }}
+      - name: Build (fonts & tools)
+        id: docker_build_fonts_tools
         uses: docker/build-push-action@v2
         with:
           push: false
           build-args: |
             LILYPOND_VERSION=${{ github.event.inputs.version }}
-            SUFFIX=-fonts-ly2video
+            SUFFIX=-fonts-tools
           tags: |
-            jeandeaual/lilypond:${{ github.event.inputs.tag}}-fonts-ly2video
-            jeandeaual/lilypond:${{ github.event.inputs.version }}-fonts-ly2video
+            jeandeaual/lilypond:${{ github.event.inputs.tag}}-fonts-tools
+            jeandeaual/lilypond:${{ github.event.inputs.version }}-fonts-tools
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64
-      - name: Image digest (fonts & ly2video)
-        run: echo ${{ steps.docker_build_ly2video.outputs.digest }}
+      - name: Image digest (fonts & tools)
+        run: echo ${{ steps.docker_build_tools.outputs.digest }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,6 @@ on:
         description: 'Image tag ("stable" or "devel")'
         required: true
         default: 'devel'
-      latest:
-        description: 'Latest'
-        required: true
-        default: 'true'
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -30,28 +26,9 @@ jobs:
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
-      - name: Build (latest)
-        id: docker_build_latest
-        uses: docker/build-push-action@v2
-        if: github.event.inputs.latest == 'true'
-        with:
-          push: false
-          build-args: |
-            LILYPOND_VERSION=${{ github.event.inputs.version }}
-          tags: |
-            jeandeaual/lilypond:latest
-            jeandeaual/lilypond:${{ github.event.inputs.tag }}
-            jeandeaual/lilypond:${{ github.event.inputs.version }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache
-          platforms: linux/amd64,linux/arm64
-      - name: Image digest (latest)
-        if: github.event.inputs.latest == 'true'
-        run: echo ${{ steps.docker_build_latest.outputs.digest }}
       - name: Build
         id: docker_build
         uses: docker/build-push-action@v2
-        if: github.event.inputs.latest != 'true'
         with:
           push: false
           build-args: |
@@ -63,7 +40,6 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
           platforms: linux/amd64,linux/arm64
       - name: Image digest
-        if: github.event.inputs.latest != 'true'
         run: echo ${{ steps.docker_build.outputs.digest }}
       - name: Build (fonts)
         id: docker_build_fonts

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ In order to run this container you'll need [Docker](https://docs.docker.com/get-
 
 All tags are available with the following variants:
 
-* `-ly2video`
+* `-tools`
 
-    Includes [ly2video](https://github.com/aspiers/ly2video).
+    Includes [ly2video](https://github.com/aspiers/ly2video) and [the Spontini editor](https://github.com/paopre/Spontini).
 
     This requires Python and makes the image quite larger.
 
@@ -74,26 +74,36 @@ All tags are available with the following variants:
 Build a file using LilyPond 2.23.0:
 
 ```sh
-docker run -v $(pwd):/app -w /app jeandeaual/lilypond:2.23.0 lilypond -dno-point-and-click main.ly
+docker run -v $(pwd):/app jeandeaual/lilypond:2.23.0 lilypond -dno-point-and-click main.ly
 ```
 
-Run ly2video on your LilyPond file (with the latest stable LilyPond version):
+Run [ly2video](https://github.com/aspiers/ly2video) on your LilyPond file (with the latest stable LilyPond version):
 
 ```sh
-docker run -v $(pwd):/app -w /app jeandeaual/lilypond:stable-ly2video ly2video -i main.ly
+docker run -v $(pwd):/app jeandeaual/lilypond:stable-tools ly2video -i main.ly
 ```
 
 Run [convert-ly](https://lilypond.org/doc/stable/Documentation/usage/invoking-convert_002dly) from the latest development version on all the LilyPond files in the current directory:
 
 ```sh
-docker run -v $(pwd):/app -w /app jeandeaual/lilypond:devel convert-ly -e *.ly
+docker run -v $(pwd):/app jeandeaual/lilypond:devel convert-ly -e *.ly
 ```
 
 Run [extractpdfmark](https://github.com/trueroad/extractpdfmark) to reduce the PDF file size:
 
 ```sh
-docker run -v $(pwd):/app -w /app jeandeaual/lilypond:devel extractpdfmark main.pdf > /tmp/tmp.ps && gs -q -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -dPDFDontUseFontObjectNum -dPrinted=false -sOutputFile=main-extracted.pdf main.pdf /tmp/tmp.ps
+docker run -v $(pwd):/app jeandeaual/lilypond:devel extractpdfmark main.pdf > /tmp/tmp.ps && gs -q -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -dPDFDontUseFontObjectNum -dPrinted=false -sOutputFile=main-extracted.pdf main.pdf /tmp/tmp.ps
 ```
+
+Run [Spontini](https://github.com/paopre/Spontini) with the latest development version of LilyPond:
+
+* Run the server:
+
+  ```sh
+  docker run -it -p 8000:8000 jeandeaual/lilypond:devel-tools spontini
+  ```
+
+* Open <http://localhost:8000/spontini-editor> in your browser
 
 ### GitHub Actions
 

--- a/build-devel.sh
+++ b/build-devel.sh
@@ -11,7 +11,7 @@ docker build \
     --build-arg LILYPOND_VERSION="${lilypond_version}" \
     .
 
-for image_suffix in "-fonts" "-ly2video" "-fonts-ly2video"; do
+for image_suffix in "-fonts" "-tools" "-fonts-tools"; do
     docker build \
         -t "jeandeaual/lilypond:devel${image_suffix}" \
         -t "jeandeaual/lilypond:${lilypond_version}${image_suffix}" \

--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,7 @@ lilypond_version="${1:-"2.22.0"}"
 
 export DOCKER_BUILDKIT=1
 
-for image_suffix in "" "-fonts" "-ly2video" "-fonts-ly2video"; do
+for image_suffix in "" "-fonts" "-tools" "-fonts-tools"; do
     docker build \
         -t "jeandeaual/lilypond:stable${image_suffix}" \
         -t "jeandeaual/lilypond:${lilypond_version}${image_suffix}" \

--- a/install-ly2video.sh
+++ b/install-ly2video.sh
@@ -13,7 +13,7 @@ usage () {
     echo "Usage: $(basename "$0")"
 }
 
-if [[ $# -gt 1 && ("$1" == "-h" || "$1" == "--help") ]]; then
+if [[ $# -ge 1 && ("$1" == "-h" || "$1" == "--help") ]]; then
     usage
     exit 0
 fi

--- a/install-spontini.sh
+++ b/install-spontini.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+set -euo pipefail
+
+command -v wget &>/dev/null || {
+    echo "wget needs to be installed" 2>&1
+    exit 1
+}
+
+usage () {
+    echo "Usage: $(basename "$0") UID GUID"
+}
+
+if [[ $# -ge 1 && ("$1" == "-h" || "$1" == "--help") ]]; then
+    usage
+    exit 0
+fi
+
+tmp_folder=$(mktemp -d)
+readonly tmp_folder
+function cleanup {
+    rm -rf "${tmp_folder}"
+}
+trap cleanup EXIT
+
+(
+    cd "${tmp_folder}"
+
+    # Spontini installation
+    wget https://github.com/paopre/Spontini/archive/refs/tags/1.2.tar.gz -O Spontini.tar.gz
+
+    tar -xzf Spontini.tar.gz
+    rm Spontini.tar.gz
+
+    mv Spontini-* /opt/Spontini
+
+    # Workaround to access Spontini from outside the container
+    sed -i 's/127\.0\.0\.1/0.0.0.0/' /opt/Spontini/lib/python/uvicorn_cli.py
+
+    cat <<'EOF' > /usr/local/bin/spontini
+#!/bin/sh
+
+python /opt/Spontini/SpontiniServer.py nogui "$@"
+EOF
+
+    chmod +x /usr/local/bin/spontini
+)


### PR DESCRIPTION
The image can be built and run like so:

```
docker build -t "jeandeaual/lilypond:devel-tools" --build-arg LILYPOND_VERSION="2.23.5" --build-arg SUFFIX="-tools" .
docker run -it -v $(pwd):/app -p 8000:8000 jeandeaual/lilypond:devel-tools spontini
```

or

```
docker build -t "jeandeaual/lilypond:devel-fonts-tools" --build-arg LILYPOND_VERSION="2.23.5" --build-arg SUFFIX="-fonts-tools" .
docker run -it v $(pwd):/app -p 8000:8000 jeandeaual/lilypond:devel-fonts-tools spontini
```

Then, Spontini should be available at <http://localhost:8000/spontini-editor>.